### PR TITLE
Fixed a problem for Windows 10 Build 10240 + IE11.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -353,17 +353,19 @@
 
 			divs[ file ].className = 'link selected';
 
-			// href     : origin + pathname + verArg + '#' + file
+			// href     : protocol + '//' + host + pathname + verArg + '#' + file
 			//         -> "http://localhost:24198/examples/index.html?webglver=2#for_phina/blendshape"
 			//
-			// origin   : http://localhost:24198
+			// protocol : http:
+			// host     : localhost:24198
 			// pathname : /examples/index.html
 			// verArg   : ?webglver=2
 			// file     : for_phina/blendshape
-			var origin = window.location.origin;
+			var protocol = window.location.protocol;
+			var host = window.location.host;
 			var pathname = window.location.pathname;
 			var verArg = (arg.webglver === '2') ? webgl2Str : '';
-			window.location.href = origin + pathname + verArg + '#' + file;
+			window.location.href = protocol + '//' + host + pathname + verArg + '#' + file;
 			
 			viewer.src = file + '/index.html' + verArg;
 			viewer.focus();


### PR DESCRIPTION
Windows 10 Build 10240 + IE11 環境にてサンプルページが見れない問題を修正。
上記環境の場合、windows.location.origin プロパティが使用できない為、protocol + host で代替え。

origin プロパティが使用できない不具合については下記参照
https://connect.microsoft.com/IE/feedback/details/1763802/location-origin-is-undefined-in-ie-11-on-windows-10-but-works-on-windows-7
